### PR TITLE
fixed data race in mock vpp adapter

### DIFF
--- a/adapter/mock/mock_vpp_adapter.go
+++ b/adapter/mock/mock_vpp_adapter.go
@@ -252,7 +252,10 @@ func (a *VppAdapter) GetMsgID(msgName string, msgCrc string) (uint16, error) {
 
 // SendMsg emulates sending a binary-encoded message to VPP.
 func (a *VppAdapter) SendMsg(clientID uint32, data []byte) error {
-	switch a.mode {
+	a.repliesLock.Lock()
+	mode := a.mode
+	a.repliesLock.Unlock()
+	switch mode {
 	case useReplyHandlers:
 		for i := len(a.replyHandlers) - 1; i >= 0; i-- {
 			replyHandler := a.replyHandlers[i]


### PR DESCRIPTION
There was a race in reading VppAdapter.mode in SendMsg and
writing in MockReply/MockReplyHandler/MockReplyWithContext.
All these *Reply* methods hold VppAdapter.repliesLock, so
this fix uses this lock to safely read the value of a mode field.

Signed-off-by: Sergey Elantsev <elantsev.s@yandex.ru>
Change-Id: I6c8873b766df6ea866196a9b96a48ebd08689772